### PR TITLE
Overhaul About page: dedicated route, bordered block layout, and copy…

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -43,7 +43,7 @@ const navLinks = siteConfig.headerNavLinks || [];
                                     rel={link.newTab ? 'noopener noreferrer' : undefined}
                                     aria-label={link.text}
                                 >
-                                    {link.text}
+                                    {link.text}{link.newTab && <span class="ml-0.5 text-[0.6rem] opacity-50 select-none" aria-hidden="true">↗</span>}
                                 </NavLink>
                             </li>
                         ))}

--- a/src/components/NavLink.astro
+++ b/src/components/NavLink.astro
@@ -10,7 +10,7 @@ const pathNorm = pathname.replace(/\/$/, '') || '/';
 const hrefStr = href != null ? String(href) : '';
 const isExternal = hrefStr.startsWith('http');
 
-/** Path only — query/hash break active matching (e.g. Bookshelf is /reads with any ?shelf=&kind=). */
+/** Path only — query/hash break active matching. Deep nav hrefs (Bookshelf, Projects tabs) still light up for the whole section. */
 let hrefPathOnly = hrefStr;
 if (!isExternal && hrefStr) {
     try {
@@ -29,6 +29,9 @@ if (isExternal) {
 } else if (hrefNorm === '/reads' || hrefNorm.startsWith('/reads/shelf')) {
     /* One nav item for the bookshelf; stay highlighted on any /reads/* route (shelves, topics, entries). */
     isActive = pathNorm === '/reads' || pathNorm.startsWith('/reads/');
+} else if (hrefNorm === '/projects' || hrefNorm.startsWith('/projects/')) {
+    /* One nav item for projects; stay highlighted on any /projects/* route (type/stack tabs, pagination, entries). */
+    isActive = pathNorm === '/projects' || pathNorm.startsWith('/projects/');
 } else {
     isActive = pathNorm === hrefNorm || pathNorm.startsWith(`${hrefNorm}/`);
 }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -24,7 +24,9 @@ const seoSchema = z.object({
 const pages = defineCollection({
     schema: z.object({
         title: z.string(),
-        seo: seoSchema.optional()
+        seo: seoSchema.optional(),
+        /** Markdown fragments for the About layout (custom page only). */
+        aboutBlocks: z.array(z.string()).optional()
     })
 });
 

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -2,13 +2,18 @@
 title: About
 seo:
   title: About — Tanner Barcelos
-  description: Full-stack engineer in the Bay Area. I build platforms for ML and shipping software—with humans and agents in the loop.
+  description: Full-stack and AI engineer building products for people and machines. Reading, writing, shipping.
+aboutBlocks:
+  - |
+    I'm Tanner. I build things for the web — **full-stack**, all the way through. The database schema, the API layer, the interface someone actually touches. I love that a single person can hold the whole picture and ship something real. That's the part I never get tired of.
+  - |
+    Right now I work at **Visa**, where I build platforms at the intersection of **machine learning and product engineering**. Control planes, federated services, UIs that make complex systems feel simple. The kind of work where good abstractions save hundreds of people time they didn't know they were losing.
+  - |
+    I've gone deep on **agentic AI** — not the hype, the craft. AI as a genuine collaborator: exploring architecture, stress-testing decisions, turning a rough idea into a working diff in one session. I think the best software is about to be built by **humans and agents together**, and I want to be at that edge.
+  - |
+    What drives me is **building products and experiences** — for users who'll never see a line of code, and for engineers who live in it every day. I care about the details: the component API that feels obvious, the deploy pipeline that just works, the error message that actually helps. **Craft** is the word. I take it seriously.
+  - |
+    Outside of code, I **read** — a lot. Fiction, technical papers, long essays. It's how I think. I **write** to make sense of what I'm learning and to leave breadcrumbs for anyone working on the same problems. Side projects are the playground. This site is one of them.
+  - |
+    Want the formal version? There's a **[resume](https://drive.google.com/file/d/1_boaCqTE2CgyBFrr7qtSEl6dvAHLKtaO/view?usp=sharing)** for that. Otherwise — I build systems people depend on, and I try to make the work feel human.
 ---
-
-I’m Tanner, a full-stack engineer based in the Bay Area. I work at Visa, where most of my time goes to the space where **machine learning meets real infrastructure**: control planes, federated services, and UIs that have to stay fast and legible when the systems behind them are anything but simple. I like the work that sits between “make the model go” and “make the team able to ship without losing their minds”—platforms, tooling, and the glue that turns a pile of services into something coherent.
-
-I care a lot about **craft at scale**. Small details in a component library matter when thirty apps inherit them. A GraphQL boundary matters when five teams stop duplicating the same fetch logic. I’m as happy in React and TypeScript as I am in Go when the problem is orchestration, reliability, or shaving seconds off a path that runs thousands of times a day. The through-line is always the same: **clarity for the people using what we build**, whether they’re engineers, analysts, or customers who will never see the repo.
-
-Lately I’ve been deep on **agentic coding**—not as a gimmick, but as a way to stay in flow. I use AI as a serious pair programmer: exploring designs, stress-testing APIs, and turning vague ideas into concrete diffs faster than I could alone. The best sessions feel like having a patient, encyclopedic collaborator who never tires of “what if we tried it this way?” I’m interested in how that changes how we review code, how we document intent, and how we keep quality high when the machine can generate so much, so fast. It’s still early, and that’s what makes it fun.
-
-Outside the job I read, tinker on side projects, and try to leave things a little more understandable than I found them. If you want the formal timeline—titles, dates, and the bullet points—there’s a **[resume (PDF)](https://drive.google.com/file/d/1_boaCqTE2CgyBFrr7qtSEl6dvAHLKtaO/view?usp=sharing)** for that. This page is the short version: **I build systems people rely on, and I’m happiest when the path from idea to production feels humane.**

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,12 +4,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 export async function getStaticPaths() {
     const pages = await getCollection('pages');
-    return pages.map((page) => {
-        return {
-            params: { slug: page.slug },
-            props: { page }
-        };
-    });
+    return pages
+        .filter((page) => page.slug !== 'about')
+        .map((page) => {
+            return {
+                params: { slug: page.slug },
+                props: { page }
+            };
+        });
 }
 
 type Props = { page: CollectionEntry<'pages'> };

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,106 @@
+---
+import { getEntry } from 'astro:content';
+import { marked } from 'marked';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const page = await getEntry('pages', 'about');
+if (!page) {
+    throw new Error('Missing content entry pages/about');
+}
+
+const { title, seo, aboutBlocks } = page.data;
+if (!aboutBlocks?.length) {
+    throw new Error('about.md must define aboutBlocks for the About page layout');
+}
+
+const htmlBlocks = aboutBlocks.map((md) => {
+    const out = marked.parse(md.trim(), { async: false });
+    if (typeof out !== 'string') {
+        throw new Error('marked.parse returned non-string; enable sync parsing for About blocks');
+    }
+    return out;
+});
+---
+
+<BaseLayout title={seo?.title ?? title} description={seo?.description} image={seo?.image} showHeader={false}>
+    <article class="about-motion pt-16 sm:pt-24 pb-20 sm:pb-28">
+        <header class="mb-14 sm:mb-20 px-4 sm:px-8">
+            <p class="font-mono text-xs text-muted mb-4 select-none">
+                <span class="opacity-50">{'// '}</span>{title.toLowerCase()}
+            </p>
+            <h1 class="font-sans text-3xl sm:text-5xl font-medium tracking-tight text-main leading-tight">
+                Who am I?
+            </h1>
+        </header>
+
+        <div
+            class="border-x-2 border-main/25 dark:border-main/35 bg-muted/15 dark:bg-muted/10"
+            aria-label="About sections"
+        >
+            {
+                htmlBlocks.map((html, i) => (
+                    <section
+                        class:list={[
+                            'about-block border-b border-main/20 dark:border-main/30 last:border-b-0',
+                            'px-5 py-10 sm:px-10 sm:py-14'
+                        ]}
+                        style={`animation-delay: ${80 + i * 110}ms`}
+                    >
+                        <div
+                            class:list={[
+                                'prose prose-dante max-w-none',
+                                '[&_p]:text-[1.05rem] sm:[&_p]:text-lg [&_p]:leading-[1.8] [&_p]:text-main/85',
+                                '[&_p+p]:mt-3'
+                            ]}
+                            set:html={html}
+                        />
+                    </section>
+                ))
+            }
+        </div>
+    </article>
+</BaseLayout>
+
+<style>
+    @keyframes about-reveal-left {
+        from {
+            opacity: 0;
+            transform: translateX(-1.25rem);
+        }
+        to {
+            opacity: 1;
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes about-reveal-right {
+        from {
+            opacity: 0;
+            transform: translateX(1.25rem);
+        }
+        to {
+            opacity: 1;
+            transform: translateX(0);
+        }
+    }
+
+    .about-block {
+        opacity: 0;
+        animation-duration: 0.72s;
+        animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+        animation-fill-mode: forwards;
+        animation-name: about-reveal-left;
+    }
+
+    .about-block:nth-child(even) {
+        animation-name: about-reveal-right;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .about-motion .about-block {
+            animation: none;
+            opacity: 1;
+            transform: none;
+        }
+    }
+</style>


### PR DESCRIPTION
… rewrite

- Add src/pages/about.astro with staggered left/right reveal animations and sharp vertical border design
- Rewrite about.md copy into concise themed blocks (full-stack, AI, craft, reading & writing)
- Extend pages schema with optional aboutBlocks field
- Exclude about from catch-all [...slug] route
- Show external-link arrow (↗) on desktop nav for newTab links