### PR TITLE
Update AI model section to clarify each model's distinct role

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -25,11 +25,7 @@ const canonicalURL = new URL(Astro.request.url, Astro.site);
 function formatCanonicalURL(url: string | URL) {
     const path = url.toString();
     const hasQueryParams = path.includes('?');
-    // If there are query params, make sure the URL has no trailing slash
-    if (hasQueryParams) {
-        path.replace(/\/?$/, '');
-    }
-    // otherwise, canonical URL always has a trailing slash
+    // Strip trailing slash when query params present; otherwise always add one
     return path.replace(/\/?$/, hasQueryParams ? '' : '/');
 }
 ---

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -77,7 +77,7 @@ const hero = siteConfig.hero;
 
         typedInstance = new Typed('#typed-tagline', {
             strings: [
-                'building AI/ML platforms',
+                'building ai/ml platforms',
                 'senior ml engineer @ visa',
                 'react · typescript · go',
                 'distributed systems',

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -10,7 +10,7 @@ const { page, class: className } = Astro.props;
                 class="font-mono text-xs text-muted hover:text-main transition-colors duration-200 px-2 py-1 -mx-2 border border-transparent hover:border-main/25 hover:bg-muted/50"
                 aria-label={`Go to page ${page.currentPage - 1} of ${page.lastPage}`}
             >
-                ← prev
+                ← Prev
             </a>
         ) : (
             <span />
@@ -28,7 +28,7 @@ const { page, class: className } = Astro.props;
                 class="font-mono text-xs text-muted hover:text-main transition-colors duration-200 px-2 py-1 -mx-2 border border-transparent hover:border-main/25 hover:bg-muted/50"
                 aria-label={`Go to page ${page.currentPage + 1} of ${page.lastPage}`}
             >
-                next →
+                Next →
             </a>
         ) : (
             <span />

--- a/src/components/ReadPreviewRow.astro
+++ b/src/components/ReadPreviewRow.astro
@@ -70,7 +70,7 @@ const topicChips = topics.slice(0, 4);
             showTopicTags && topicChips.length > 0 && (
                 <div class="mt-2 flex flex-wrap gap-1.5">
                     {topicChips.map((t) => (
-                        <span class="font-mono text-[0.65rem] uppercase tracking-wide text-muted/70 px-1.5 py-0.5 leading-tight border border-main/15 bg-main/[0.04] dark:bg-main/[0.06] dark:border-main/20">
+                        <span class="font-mono text-xs uppercase tracking-wide text-muted/70 px-1.5 py-0.5 leading-tight border border-main/15 bg-main/[0.04] dark:bg-main/[0.06] dark:border-main/20">
                             {t}
                         </span>
                     ))}

--- a/src/components/ReadsBrowseStrip.astro
+++ b/src/components/ReadsBrowseStrip.astro
@@ -84,7 +84,7 @@ function topicChipTitle(t: TopicBrowseItem): string {
     </summary>
     <div class="pt-4 pb-2 sm:pt-5 sm:pb-3 mt-3 space-y-8 border-t border-main/10">
         <div>
-            <p class="font-mono text-[0.65rem] uppercase tracking-wider text-muted/70 mb-3">Format</p>
+            <p class="font-mono text-xs uppercase tracking-wider text-muted/70 mb-3">Format</p>
             <div class="flex flex-wrap gap-2">
                 <a
                     href={shelf !== undefined ? withReadsBrowseQuery(path, { shelf }) : withReadsBrowseQuery(path, {})}
@@ -123,7 +123,7 @@ function topicChipTitle(t: TopicBrowseItem): string {
             topics.length > 0 && (
                 <div>
                     <div class="flex items-baseline justify-between gap-4 mb-3">
-                        <p class="font-mono text-[0.65rem] uppercase tracking-wider text-muted/70">Topics</p>
+                        <p class="font-mono text-xs uppercase tracking-wider text-muted/70">Topics</p>
                         <a
                             href={shelf !== undefined ? `/reads/topics/${shelf}/` : '/reads/topics/'}
                             data-topics-index-link=""

--- a/src/pages/reads/topic/[topic].astro
+++ b/src/pages/reads/topic/[topic].astro
@@ -54,7 +54,7 @@ const urlShelf = parseShelfFromQuery(Astro.url.searchParams.get('shelf'));
         </p>
         <h1 class="font-sans text-3xl sm:text-4xl font-medium tracking-tight text-main mb-3">{topicLabel}</h1>
         <p class="text-muted text-sm sm:text-base leading-relaxed max-w-2xl mb-10 sm:mb-12">
-            Entries tagged here; open the funnel control to filter by format or other topics.
+            All entries tagged with this topic. Use the filter above to refine by format or other topics.
         </p>
 
         <BookshelfShelfToggle pathname={Astro.url.pathname}>

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -187,8 +187,8 @@ const modelRankings: RankItem[] = [
             { label: 'research', tone: 'sky' },
             { label: 'tech', tone: 'emerald' }
         ],
-        body: 'Opus 4.6 is where I go for hardcore reasoning and technical research. It is the model I trust most when the task is messy, the architecture is unclear, or I want a strong thinking partner on difficult engineering tradeoffs.',
-        pros: ['Excellent for deep technical reasoning and architecture work', 'Strong at research-heavy problem framing and critique'],
+        body: 'Opus 4.6 is my heavy-focus model — where I go for deep research, long-form technical discussions, and anything that demands sustained reasoning. It is the model I trust most when the task is messy, the architecture is unclear, or I want a serious thinking partner on difficult engineering tradeoffs. If I need to go deep, I open Claude.',
+        pros: ['Best-in-class for deep research and long-form technical discussion', 'Excellent for architecture reasoning, critique, and problem framing', 'The model I trust most for sustained, focused intellectual work'],
         cons: ['Slower and more expensive than faster editor-native options', 'Not the model I reach for first when the task is mostly visual iteration or quick tasks']
     },
     {
@@ -202,9 +202,9 @@ const modelRankings: RankItem[] = [
             { label: 'general assistant', tone: 'neutral' },
             { label: 'up-to-date', tone: 'sky' }
         ],
-        body: 'GPT 5.4 sits below Opus and Composer 2 for how I route most work, but it is still incredible for building modern tools and software. It has fast, reliable tool calling and will often one-shot a feature or feedback pass when I give it a strong prompt, and the more up-to-date training data shows up in newer APIs, libraries, and patterns.',
-        pros: ['Fast, reliable tool calling with strong one-shot implementation ability', 'Very strong for building modern software against newer tooling', 'Nice for general conversations and non-technical tasks'],
-        cons: ['Opus and Composer 2 still win for my default reasoning and in-editor loops', 'I review output carefully on anything production-critical']
+        body: 'GPT 5.4 is my go-to general assistant for text-based work. I lean on it for general conversations, general technical discussions, and building against modern tooling — anywhere that is not image-heavy. It has fast, reliable tool calling and will often one-shot a feature or feedback pass when I give it a strong prompt, and the more up-to-date training data shows up in newer APIs, libraries, and patterns.',
+        pros: ['My primary general assistant for non-image work', 'Fast, reliable tool calling with strong one-shot implementation ability', 'Great for general technical conversations and modern software development'],
+        cons: ['Opus and Composer 2 still win for my default deep reasoning and in-editor loops', 'I review output carefully on anything production-critical']
     },
     {
         rank: '04',
@@ -212,10 +212,11 @@ const modelRankings: RankItem[] = [
         icon: siGooglegemini,
         tags: [
             { label: 'general assistant', tone: 'neutral' },
-            { label: 'multimodal', tone: 'violet' }
+            { label: 'multimodal', tone: 'violet' },
+            { label: 'image gen', tone: 'sky' }
         ],
-        body: 'I use Gemini 3.1 Pro in the Gemini app for everyday, non-technical conversations — travel, drafting, general chat — separate from my coding harnesses. It has the full breadth of Google behind it, which shows up in multimodal workflows and general knowledge.',
-        pros: ['Strong multimodal and long-context workflows in the app', 'Great breadth for general chatting and non-technical assistant tasks'],
+        body: 'Gemini is also a general assistant in my rotation, but it has a distinct lane: I lean on it for image generation and quick, lightweight tasks where I want something fast and low-friction. It has the full breadth of Google behind it, which shows up in multimodal workflows and general knowledge. When I want to generate an image or knock out something small, Gemini is usually where I start.',
+        pros: ['My default pick for image generation', 'Great for quick, lightweight tasks and everyday general chat', 'Strong multimodal and long-context workflows in the app'],
         cons: [
             'Not where I lean for agent harnesses or agentic coding workloads right now — tool calling is not strong enough compared to my top picks',
             'Not my primary coding agent and less integrated into my editor-centric loop',

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -202,8 +202,8 @@ const modelRankings: RankItem[] = [
             { label: 'general assistant', tone: 'neutral' },
             { label: 'up-to-date', tone: 'sky' }
         ],
-        body: 'GPT 5.4 is my go-to general assistant for text-based work. I lean on it for general conversations, general technical discussions, and building against modern tooling — anywhere that is not image-heavy. It has fast, reliable tool calling and will often one-shot a feature or feedback pass when I give it a strong prompt, and the more up-to-date training data shows up in newer APIs, libraries, and patterns.',
-        pros: ['My primary general assistant for non-image work', 'Fast, reliable tool calling with strong one-shot implementation ability', 'Great for general technical conversations and modern software development'],
+        body: 'GPT 5.4 is my primary general assistant. I reach for it for everyday conversations, general technical discussions, and building against modern tooling. It has fast, reliable tool calling and will often one-shot a feature or feedback pass when I give it a strong prompt, and the more up-to-date training data shows up in newer APIs, libraries, and patterns.',
+        pros: ['My primary general assistant for everyday and technical conversations', 'Fast, reliable tool calling with strong one-shot implementation ability', 'Very strong for building modern software against newer tooling'],
         cons: ['Opus and Composer 2 still win for my default deep reasoning and in-editor loops', 'I review output carefully on anything production-critical']
     },
     {
@@ -215,8 +215,8 @@ const modelRankings: RankItem[] = [
             { label: 'multimodal', tone: 'violet' },
             { label: 'image gen', tone: 'sky' }
         ],
-        body: 'Gemini is also a general assistant in my rotation, but it has a distinct lane: I lean on it for image generation and quick, lightweight tasks where I want something fast and low-friction. It has the full breadth of Google behind it, which shows up in multimodal workflows and general knowledge. When I want to generate an image or knock out something small, Gemini is usually where I start.',
-        pros: ['My default pick for image generation', 'Great for quick, lightweight tasks and everyday general chat', 'Strong multimodal and long-context workflows in the app'],
+        body: 'Gemini is my pick for fast, one-off chats and image generation in the app. It is not where I go for deep work, but it is great when I want a quick answer or need to generate an image without switching contexts. The full breadth of Google behind it makes it reliable for everyday general use.',
+        pros: ['Great for fast, one-off chats where I want a quick answer', 'My go-to for image generation in the app', 'Strong multimodal and long-context workflows'],
         cons: [
             'Not where I lean for agent harnesses or agentic coding workloads right now — tool calling is not strong enough compared to my top picks',
             'Not my primary coding agent and less integrated into my editor-centric loop',

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -241,7 +241,7 @@ const harnessRankings: RankItem[] = [
             'Multi-surface clients (agents UI, editor, CLI) that all consume the same models and agents on my subscription'
 
         ],
-        cons: ['Platform churn still happens from time to time, espeically for research tasks']
+        cons: ['Platform churn still happens from time to time, especially for research tasks']
     },
     {
         rank: '02',
@@ -283,7 +283,7 @@ function tagClasses(tone: RankItem['tags'][number]['tone']) {
                 class="mt-6 max-w-2xl border-l border-main/20 dark:border-main/25 pl-3.5 text-[0.7rem] sm:text-xs text-muted/75 dark:text-muted/70 leading-relaxed tracking-wide"
             >
                 <span class="font-mono text-muted/90">Disclaimer.</span>{' '}
-                Rankings here are my personal opinions — not universal truth or a live snapshot of the current state of thefield. I still
+                Rankings here are my personal opinions — not universal truth or a live snapshot of the current state of the field. I still
                 review anything that touches production; models speed exploration but do not replace ownership.
             </p>
         </header>


### PR DESCRIPTION
- Claude Opus 4.6: reframed as the heavy-focus model for deep research and long-form technical discussions
- GPT 5.4: explicitly positioned as general assistant for non-image work, including general technical conversations
- Gemini 3.1 Pro: also general assistant, but distinct lane for image generation and quick lightweight tasks; added 'image gen' tag

https://claude.ai/code/session_01BraVTnJRjawJdHQL5YZ5py