### PR TITLE
Replace typed.js with Claude Code-style hero animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
         "astro": "^5.12.0",
         "marked": "^14.1.2",
         "simple-icons": "^16.16.0",
-        "tailwindcss": "^3.4.11",
-        "typed.js": "^3.0.0"
+        "tailwindcss": "^3.4.11"
     },
     "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -75,21 +75,21 @@ const hero = siteConfig.hero;
         opacity: 0;
     }
 
-    /* ── Claude logo breathe ── */
+    /* ── Claude logo breathe — neutral white/light, not accent ── */
     #claude-logo {
-        color: rgb(var(--color-accent));
+        color: rgb(var(--color-text-main));
         transform-origin: center;
-        opacity: 0.4;
+        opacity: 0.35;
     }
 
     @keyframes logo-breathe {
         0%,
         100% {
-            opacity: 0.3;
+            opacity: 0.25;
             transform: scale(0.9);
         }
         50% {
-            opacity: 1;
+            opacity: 0.9;
             transform: scale(1);
         }
     }
@@ -98,32 +98,34 @@ const hero = siteConfig.hero;
         animation: logo-breathe 1.3s ease-in-out infinite;
     }
 
-    /* ── Phrase text with left-to-right shimmer sweep ── */
+    /* ── Phrase text: letter-fill color sweep (not an overlay) ── */
+    /* Uses @property --tagline-sw (defined in global.css) to animate the
+       gradient stop position, making letter fills change color left-to-right */
     #tagline-phrase {
-        color: rgb(var(--color-text-main) / 0.85);
-        position: relative;
-        overflow: hidden;
+        background: linear-gradient(
+            90deg,
+            rgb(var(--color-text-main) / 0.85) calc(var(--tagline-sw) - 14%),
+            rgb(var(--color-sweep-highlight))   var(--tagline-sw),
+            rgb(var(--color-text-main) / 0.85) calc(var(--tagline-sw) + 14%)
+        );
+        background-clip: text;
+        -webkit-background-clip: text;
+        color: transparent;
+        -webkit-text-fill-color: transparent;
     }
 
+    /* Two left-to-right sweeps per phrase with a gap between them.
+       Total: sweep1 (43.3%) + instant reset + gap (13.4%) + sweep2 (43.3%) = 3s */
     @keyframes phrase-sweep {
-        from {
-            transform: translateX(-100%);
-        }
-        to {
-            transform: translateX(200%);
-        }
+        0%     { --tagline-sw: -20%; }
+        43.3%  { --tagline-sw: 120%; }
+        43.4%  { --tagline-sw: -20%; }
+        56.7%  { --tagline-sw: -20%; }
+        100%   { --tagline-sw: 120%; }
     }
 
-    #tagline-phrase.is-sweeping::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 50%;
-        background: linear-gradient(90deg, transparent, rgb(var(--color-accent) / 0.45), transparent);
-        pointer-events: none;
-        animation: phrase-sweep 1.3s ease-in-out 1 forwards;
+    #tagline-phrase.is-sweeping {
+        animation: phrase-sweep 3s ease-in-out 1 forwards;
     }
 
     /* ── Reduced motion ── */
@@ -133,9 +135,16 @@ const hero = siteConfig.hero;
             opacity: 0.35;
         }
 
+        /* Restore plain text color — background-clip: text won't animate */
+        #tagline-phrase {
+            background: none;
+            color: rgb(var(--color-text-main) / 0.85);
+            -webkit-text-fill-color: rgb(var(--color-text-main) / 0.85);
+        }
+
         #claude-logo.is-breathing {
             animation: none;
-            opacity: 0.6;
+            opacity: 0.55;
             transform: scale(1);
         }
 
@@ -157,8 +166,8 @@ const hero = siteConfig.hero;
     ] as const;
 
     const FADE_MS  = 300;
-    const SWEEP_MS = 1300;
-    const HOLD_MS  = 1600;
+    const SWEEP_MS = 3000;  // two sweeps × 1.3 s + 0.4 s gap
+    const HOLD_MS  = 1500;
 
     type State = 'idle' | 'active' | 'fading';
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -156,12 +156,10 @@ const hero = siteConfig.hero;
 
 <script>
     const PHRASES = [
-        'building ai/ml platforms',
+        'building ai developer tools',
         'senior ml engineer @ visa',
-        'react · typescript · go',
-        'distributed systems',
-        'ai enthusiast',
-        'building developer tooling',
+        'web & agent enthusiast',
+        'avid book reader',
         'silicon valley'
     ] as const;
 
@@ -196,9 +194,8 @@ const hero = siteConfig.hero;
 
         switch (state) {
             case 'idle': {
-                // Clean up previous phrase's animations
+                // Clean up sweep from previous phrase; logo keeps breathing uninterrupted
                 phrase.classList.remove('is-sweeping');
-                logo.classList.remove('is-breathing');
                 // Set new phrase text while row is faded out
                 phrase.textContent = PHRASES[phraseIndex];
                 // Ensure row is faded, then trigger fade-in via double rAF
@@ -213,9 +210,8 @@ const hero = siteConfig.hero;
                 break;
             }
             case 'active': {
-                // Start sweep and logo breathe together
+                // Start sweep (logo already breathing continuously from init)
                 phrase.classList.add('is-sweeping');
-                logo.classList.add('is-breathing');
                 state = 'fading';
                 timerId = setTimeout(tick, SWEEP_MS + HOLD_MS);
                 break;
@@ -263,6 +259,9 @@ const hero = siteConfig.hero;
         if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
             initReducedMotion();
         } else {
+            // Start logo breathing immediately; it runs continuously until destroy
+            const { logo } = getEls();
+            if (logo) logo.classList.add('is-breathing');
             timerId = setTimeout(tick, 250);
         }
     }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,4 +1,5 @@
 ---
+import { siClaude } from 'simple-icons';
 import Button from './Button.astro';
 import siteConfig from '../data/site-config';
 
@@ -13,9 +14,21 @@ const hero = siteConfig.hero;
         Tanner Barcelos<span class="name-cursor" aria-hidden="true" />
     </h1>
 
-    {/* Typed rotating tagline */}
-    <div class="hero-tagline font-mono text-sm sm:text-base text-muted mb-12 min-h-[1.5rem] tracking-tight">
-        <span id="typed-tagline" class="text-main/85"></span>
+    {/* Claude Code–style animated tagline */}
+    <div class="hero-tagline font-mono text-sm sm:text-base mb-12 min-h-[1.5rem] tracking-tight">
+        <div id="tagline-row" class="inline-flex items-center gap-2">
+            <svg
+                id="claude-logo"
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                class="shrink-0"
+                style="width:14px;height:14px;"
+            >
+                <path fill="currentColor" d={siClaude.path} />
+            </svg>
+            <span id="tagline-phrase" aria-live="polite" aria-atomic="true"></span>
+        </div>
     </div>
 
     {/* CTA buttons — optional; tagline stays even with no actions */}
@@ -33,7 +46,7 @@ const hero = siteConfig.hero;
 </section>
 
 <style>
-    /* Blinking underscore cursor on the name */
+    /* ── Name cursor (unchanged) ── */
     .name-cursor::after {
         content: '_';
         animation: cursor-blink 1.1s step-end infinite;
@@ -53,56 +66,211 @@ const hero = siteConfig.hero;
         }
     }
 
+    /* ── Tagline row fade ── */
+    #tagline-row {
+        transition: opacity 0.3s ease-in-out;
+    }
+
+    #tagline-row.is-fading {
+        opacity: 0;
+    }
+
+    /* ── Claude logo breathe ── */
+    #claude-logo {
+        color: rgb(var(--color-accent));
+        transform-origin: center;
+        opacity: 0.4;
+    }
+
+    @keyframes logo-breathe {
+        0%,
+        100% {
+            opacity: 0.3;
+            transform: scale(0.9);
+        }
+        50% {
+            opacity: 1;
+            transform: scale(1);
+        }
+    }
+
+    #claude-logo.is-breathing {
+        animation: logo-breathe 1.3s ease-in-out infinite;
+    }
+
+    /* ── Phrase text with left-to-right shimmer sweep ── */
+    #tagline-phrase {
+        color: rgb(var(--color-text-main) / 0.85);
+        position: relative;
+        overflow: hidden;
+    }
+
+    @keyframes phrase-sweep {
+        from {
+            transform: translateX(-100%);
+        }
+        to {
+            transform: translateX(200%);
+        }
+    }
+
+    #tagline-phrase.is-sweeping::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 50%;
+        background: linear-gradient(90deg, transparent, rgb(var(--color-accent) / 0.45), transparent);
+        pointer-events: none;
+        animation: phrase-sweep 1.3s ease-in-out 1 forwards;
+    }
+
+    /* ── Reduced motion ── */
     @media (prefers-reduced-motion: reduce) {
         .name-cursor::after {
             animation: none;
             opacity: 0.35;
         }
+
+        #claude-logo.is-breathing {
+            animation: none;
+            opacity: 0.6;
+            transform: scale(1);
+        }
+
+        #tagline-row {
+            transition: opacity 0.15s ease;
+        }
     }
 </style>
 
 <script>
-    import Typed from 'typed.js';
+    const PHRASES = [
+        'building ai/ml platforms',
+        'senior ml engineer @ visa',
+        'react · typescript · go',
+        'distributed systems',
+        'ai enthusiast',
+        'building developer tooling',
+        'silicon valley'
+    ] as const;
 
-    let typedInstance: InstanceType<typeof Typed> | null = null;
+    const FADE_MS  = 300;
+    const SWEEP_MS = 1300;
+    const HOLD_MS  = 1600;
 
-    function initTyped() {
-        const el = document.getElementById('typed-tagline');
-        if (!el) return;
+    type State = 'idle' | 'active' | 'fading';
 
-        if (typedInstance) {
-            typedInstance.destroy();
-            typedInstance = null;
-        }
+    let phraseIndex = 0;
+    let state: State = 'idle';
+    let timerId: ReturnType<typeof setTimeout> | null = null;
 
-        typedInstance = new Typed('#typed-tagline', {
-            strings: [
-                'building ai/ml platforms',
-                'senior ml engineer @ visa',
-                'react · typescript · go',
-                'distributed systems',
-                'ai enthusiast',
-                'building developer tooling',
-                'silicon valley'
-            ],
-            typeSpeed: 42,
-            backSpeed: 22,
-            backDelay: 2200,
-            startDelay: 250,
-            loop: true,
-            cursorChar: '_',
-            smartBackspace: false,
-            contentType: 'text'
-        });
+    function getEls() {
+        return {
+            row:    document.getElementById('tagline-row'),
+            phrase: document.getElementById('tagline-phrase'),
+            logo:   document.getElementById('claude-logo'),
+        };
     }
 
-    document.addEventListener('astro:before-swap', () => {
-        if (typedInstance) {
-            typedInstance.destroy();
-            typedInstance = null;
+    function clearTimer() {
+        if (timerId !== null) {
+            clearTimeout(timerId);
+            timerId = null;
         }
-    });
+    }
 
-    document.addEventListener('astro:page-load', initTyped);
-    initTyped();
+    function tick() {
+        const { row, phrase, logo } = getEls();
+        if (!row || !phrase || !logo) return;
+
+        switch (state) {
+            case 'idle': {
+                // Clean up previous phrase's animations
+                phrase.classList.remove('is-sweeping');
+                logo.classList.remove('is-breathing');
+                // Set new phrase text while row is faded out
+                phrase.textContent = PHRASES[phraseIndex];
+                // Ensure row is faded, then trigger fade-in via double rAF
+                row.classList.add('is-fading');
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        row.classList.remove('is-fading');
+                        state = 'active';
+                        timerId = setTimeout(tick, FADE_MS);
+                    });
+                });
+                break;
+            }
+            case 'active': {
+                // Start sweep and logo breathe together
+                phrase.classList.add('is-sweeping');
+                logo.classList.add('is-breathing');
+                state = 'fading';
+                timerId = setTimeout(tick, SWEEP_MS + HOLD_MS);
+                break;
+            }
+            case 'fading': {
+                // Fade out, then advance to next phrase
+                row.classList.add('is-fading');
+                phraseIndex = (phraseIndex + 1) % PHRASES.length;
+                state = 'idle';
+                timerId = setTimeout(tick, FADE_MS);
+                break;
+            }
+        }
+    }
+
+    function initReducedMotion() {
+        const { row, phrase, logo } = getEls();
+        if (!row || !phrase || !logo) return;
+
+        phrase.textContent = PHRASES[phraseIndex];
+        row.classList.remove('is-fading');
+
+        function cycle() {
+            const { row: r, phrase: p } = getEls();
+            if (!r || !p) return;
+            r.classList.add('is-fading');
+            timerId = setTimeout(() => {
+                phraseIndex = (phraseIndex + 1) % PHRASES.length;
+                const { row: r2, phrase: p2 } = getEls();
+                if (!r2 || !p2) return;
+                p2.textContent = PHRASES[phraseIndex];
+                r2.classList.remove('is-fading');
+                timerId = setTimeout(cycle, 3000);
+            }, 150);
+        }
+
+        timerId = setTimeout(cycle, 3000);
+    }
+
+    function initAnimation() {
+        phraseIndex = 0;
+        state = 'idle';
+        clearTimer();
+
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            initReducedMotion();
+        } else {
+            timerId = setTimeout(tick, 250);
+        }
+    }
+
+    function destroyAnimation() {
+        clearTimer();
+        const { row, phrase, logo } = getEls();
+        if (row) row.classList.remove('is-fading');
+        if (phrase) {
+            phrase.classList.remove('is-sweeping');
+            phrase.textContent = '';
+        }
+        if (logo) logo.classList.remove('is-breathing');
+        state = 'idle';
+    }
+
+    document.addEventListener('astro:before-swap', destroyAnimation);
+    document.addEventListener('astro:page-load', initAnimation);
+    initAnimation();
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Animatable custom property for the tagline letter-fill sweep */
+@property --tagline-sw {
+    syntax: '<percentage>';
+    inherits: false;
+    initial-value: -20%;
+}
+
 @layer base {
     /* ─── Light mode — warm paper ─── */
     :root {
@@ -11,6 +18,7 @@
         --color-bg-muted: 236 235 228;    /* #ECEBE4 */
         --color-border-main: 214 212 206; /* #D6D4CE */
         --color-accent: 145 90 48;
+        --color-sweep-highlight: var(--color-accent); /* amber in light mode */
     }
 
     /* ─── Dark mode — editor dark ─── */
@@ -22,6 +30,7 @@
         --color-bg-muted: 22 22 19;       /* #161613 */
         --color-border-main: 40 39 35;    /* #282723 */
         --color-accent: 212 168 120;
+        --color-sweep-highlight: 220 218 213; /* near-white warm in dark mode */
     }
 
     @keyframes cursor-blink {


### PR DESCRIPTION
Swap the typewriter effect for a Claude Code–inspired animation: a small
Claude logo that breathes (opacity + scale) alongside a left-to-right
shimmer sweep over each phrase. Phrases cycle every 3.5 s with an opacity
cross-fade. Removes the typed.js dependency entirely. Respects
prefers-reduced-motion (simple opacity cycle, no animations).

https://claude.ai/code/session_01N84UBXDBv7tas5tZypp5Fc